### PR TITLE
Update mutator

### DIFF
--- a/src/reactea/chem/chem_utils.py
+++ b/src/reactea/chem/chem_utils.py
@@ -1,6 +1,8 @@
+import random
 from itertools import chain
 from typing import Union, List
 
+import numpy as np
 from rdkit import DataStructs, Chem
 from rdkit.Chem import Mol, rdmolfiles, rdmolops, MolFromSmiles, MolToSmiles, RemoveHs
 from rdkit.Chem.Draw import MolToImage
@@ -174,7 +176,7 @@ class ChemUtils:
         return 0.0
 
     @staticmethod
-    def most_similar_compound(smiles: str, smiles_list: List[str]):
+    def most_similar_compound(smiles: str, smiles_list: List[str], tolerance: float = 0.25):
         """
         Finds the most similar compound in a list of compounds.
 
@@ -184,6 +186,8 @@ class ChemUtils:
             The smiles of the compound to find the most similar compound for.
         smiles_list: List[str]
             The list of compounds to find the most similar compound in.
+        tolerance: float
+            Compounds between max_similarity and max_similarity - tolerance are considered to be picked.
 
         Returns
         -------
@@ -193,5 +197,5 @@ class ChemUtils:
         if len(smiles_list) == 1:
             return smiles_list[0]
         sims = [ChemUtils.calc_fingerprint_similarity(smiles, s) for s in smiles_list]
-        matching = sims.index(max(sims))
-        return smiles_list[matching]
+        idx = [i for i, x in enumerate(sims) if x >= max(sims) - tolerance]
+        return smiles_list[random.choice(idx)]

--- a/src/reactea/constants.py
+++ b/src/reactea/constants.py
@@ -43,6 +43,8 @@ class EAConstants:
     MUTATION = ReactorMutation
     # Mutation Probability
     MUTATION_PROBABILITY = 1.0
+    # Tolerance for the Mutation Similarity
+    TOLERANCE = 0.25
     # Crossover
     CROSSOVER = ReactorPseudoCrossover
     # Crossover probability

--- a/src/reactea/optimization/jmetal/ea.py
+++ b/src/reactea/optimization/jmetal/ea.py
@@ -90,13 +90,15 @@ class ChemicalEA(AbstractEA):
                                         self.reaction_rules,
                                         self.standardizer,
                                         self.configs,
-                                        self.logger)
+                                        self.logger,
+                                        EAConstants.TOLERANCE)
         try:
             crossover = EAConstants.CROSSOVER(EAConstants.CROSSOVER_PROBABILITY,
                                               self.reaction_rules,
                                               self.standardizer,
                                               self.configs,
-                                              self.logger
+                                              self.logger,
+                                              EAConstants.TOLERANCE
                                               )
         except TypeError:
             crossover = EAConstants.CROSSOVER()
@@ -166,13 +168,15 @@ class ChemicalEA(AbstractEA):
                                         self.reaction_rules,
                                         self.standardizer,
                                         self.configs,
-                                        self.logger)
+                                        self.logger,
+                                        EAConstants.TOLERANCE)
         try :
             crossover = EAConstants.CROSSOVER(EAConstants.CROSSOVER_PROBABILITY,
                                               self.reaction_rules,
                                               self.standardizer,
                                               self.configs,
-                                              self.logger
+                                              self.logger,
+                                              EAConstants.TOLERANCE
                                               )
         except TypeError:
             crossover = EAConstants.CROSSOVER()

--- a/src/reactea/optimization/jmetal/operators.py
+++ b/src/reactea/optimization/jmetal/operators.py
@@ -23,7 +23,8 @@ class ReactorMutation(Mutation[ChemicalSolution]):
                  reaction_rules: List[ReactionRule],
                  standardizer: Union[MolecularStandardizer, None],
                  configs: dict,
-                 logger: Union[callable, None] = None):
+                 logger: Union[callable, None] = None,
+                 tolerance: float = 0.25):
         """
         Initializes a ReactorMutation operator.
 
@@ -39,12 +40,15 @@ class ReactorMutation(Mutation[ChemicalSolution]):
             configurations of the experiment
         logger: Union[callable, None]
             function to save all intermediate transformations (accepted and not accepted)
+        tolerance: float
+            compounds between max_similarity and max_similarity - tolerance are considered to be picked as mutant.
         """
         super(ReactorMutation, self).__init__(probability=probability)
         self.reaction_rules = reaction_rules
         self.standardizer = standardizer
         self.configs = configs
         self.logger = logger
+        self.tolerance = tolerance
 
     def execute(self, solution: ChemicalSolution):
         """
@@ -76,7 +80,7 @@ class ReactorMutation(Mutation[ChemicalSolution]):
                 products = [pd for pd in products if ChemUtils.valid_product(pd)]
                 if len(products) > 0:
                     # keep the most similar compound
-                    most_similar_product = ChemUtils.most_similar_compound(compound.smiles, products)
+                    most_similar_product = ChemUtils.most_similar_compound(compound.smiles, products, self.tolerance)
                     mutant_id = f"{compound.cmp_id}--{rule.rule_id}_"
                     if not isinstance(most_similar_product, str):
                         products = []
@@ -122,7 +126,8 @@ class ReactorPseudoCrossover(Crossover[ChemicalSolution, ChemicalSolution]):
                  reaction_rules: List[ReactionRule],
                  standardizer: Union[MolecularStandardizer, None],
                  configs: dict,
-                 logger: Union[callable, None] = None):
+                 logger: Union[callable, None] = None,
+                 tolerance: float = 0.25):
         """
         Initializes a ReactorPseudoCrossover operator.
 
@@ -138,12 +143,15 @@ class ReactorPseudoCrossover(Crossover[ChemicalSolution, ChemicalSolution]):
             configurations of the experiment
         logger: Union[callable, None]
             function to save all intermediate transformations (accepted and not accepted)
+        tolerance: float
+            compounds between max_similarity and max_similarity - tolerance are considered to be picked as mutant.
         """
         super(ReactorPseudoCrossover, self).__init__(probability=probability)
         self.reaction_rules = reaction_rules
         self.standardizer = standardizer
         self.configs = configs
         self.logger = logger
+        self.tolerance = tolerance
 
     def execute(self, parent: List[ChemicalSolution]):
         """
@@ -168,7 +176,8 @@ class ReactorPseudoCrossover(Crossover[ChemicalSolution, ChemicalSolution]):
                                           self.reaction_rules,
                                           self.standardizer,
                                           self.configs,
-                                          self.logger).execute(offspring[0])
+                                          self.logger,
+                                          self.tolerance).execute(offspring[0])
             offspring[0] = m_offspring
         return offspring
 


### PR DESCRIPTION
Allow flexible (random) picking of similar compounds (with a tolerance) as a mutant (not always the most similar).

Now a list of the most similar compounds within a range is used as a base for a random picking of the new mutant.
Previously always the most similar was picked.