### PR TITLE
[FIX] get_results to return all solutions

### DIFF
--- a/src/reactea/optimization/jmetal/algorithms.py
+++ b/src/reactea/optimization/jmetal/algorithms.py
@@ -101,3 +101,14 @@ class ReactorEvolutionStrategy(EvolutionStrategy):
             unique_population.extend(population_pool[:self.mu - len(unique_population)])
 
         return unique_population
+
+    def get_result(self):
+        """
+        Get the EA results.
+
+        Returns
+        -------
+        List[Solutions]:
+            list of the EA solutions.
+        """
+        return self.solutions


### PR DESCRIPTION
Evolution Strategy to work with population size > 1.
`get_results` method was only returning the first solution.