### PR TITLE
[FIX] avoid inadequate termination reaching when maximization

### DIFF
--- a/src/reactea/optimization/jmetal/terminators.py
+++ b/src/reactea/optimization/jmetal/terminators.py
@@ -98,6 +98,10 @@ class StoppingByEvaluationsOrImprovement(TerminationCriterion):
             mean_fit = np.mean(solutions.objectives)
 
         mean_fit = mean_fit * -1  # minimization
+
+        if self.evaluations == 0:
+            self.value = mean_fit
+
         if self.value >= mean_fit:
             self.no_improvement += 1
         else:


### PR DESCRIPTION
Fix termination by evaluations or no improvement.
When facing minimization problems (minimization for jmetalpy) improvement was compared with 0.0 which for negative values resulted in inadequate behavior.